### PR TITLE
Update ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,6 +4,6 @@ defined('TYPO3_MODE') || die();
 
 call_user_func(function ($extensionKey) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
-        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . 'Configuration/TypoScript/Extbase/setup.typoscrript">'
+        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/TypoScript/Extbase/setup.typoscrript">'
     );
 }, 'static_info_tables_ro');


### PR DESCRIPTION
A slash is missing when composing the path name. This prevents the typoscript from being loaded. Correction by adding a slash.